### PR TITLE
Fix: Enable image scrolling in dashboard modal

### DIFF
--- a/dev.log
+++ b/dev.log
@@ -1,0 +1,15 @@
+
+> unistay@0.1.0 dev
+> next dev
+
+   ▲ Next.js 15.3.5
+   - Local:        http://localhost:3000
+   - Network:      http://192.168.0.2:3000
+
+ ✓ Starting...
+Attention: Next.js now collects completely anonymous telemetry regarding usage.
+This information is used to shape Next.js' roadmap and prioritize features.
+You can learn more, including how to opt-out if you'd not like to participate in this anonymous program, by visiting the following URL:
+https://nextjs.org/telemetry
+
+ ✓ Ready in 1925ms

--- a/src/components/DashboardContent.tsx
+++ b/src/components/DashboardContent.tsx
@@ -102,6 +102,8 @@ export default function DashboardContent() {
     isOpen: false,
     src: '',
     alt: '',
+    allImages: [],
+    initialIndex: 0
   })
 
   // Helper functions for modals
@@ -121,14 +123,20 @@ export default function DashboardContent() {
     setNotificationModal(prev => ({ ...prev, isOpen: false }))
   }
 
-  const openImageModal = (src: string | null, alt: string) => {
+  const openImageModal = (src: string | null, alt: string, allImages?: string[], initialIndex?: number) => {
     if (src) {
-      setImageModal({ isOpen: true, src, alt })
+      setImageModal({
+        isOpen: true,
+        src,
+        alt,
+        allImages: allImages || (src ? [src] : []),
+        initialIndex: initialIndex || 0
+      })
     }
   }
 
   const closeImageModal = () => {
-    setImageModal({ isOpen: false, src: '', alt: '' })
+    setImageModal({ isOpen: false, src: '', alt: '', allImages: [], initialIndex: 0 })
   }
 
   // Update active tab from URL (only on initial load)
@@ -584,6 +592,8 @@ export default function DashboardContent() {
         onClose={closeImageModal}
         src={imageModal.src}
         alt={imageModal.alt}
+        allImages={imageModal.allImages}
+        initialIndex={imageModal.initialIndex}
       />
 
       <ApplicationModal

--- a/src/components/dashboard/AgentProperties.tsx
+++ b/src/components/dashboard/AgentProperties.tsx
@@ -13,7 +13,7 @@ interface AgentPropertiesProps {
 
 interface PropertyImageCarouselProps {
   property: Property
-  onImageClick: (src: string | null, alt: string) => void
+  onImageClick: (src: string | null, alt: string, allImages?: string[], index?: number) => void
 }
 
 function PropertyImageCarousel({ property, onImageClick }: PropertyImageCarouselProps) {
@@ -86,7 +86,9 @@ function PropertyImageCarousel({ property, onImageClick }: PropertyImageCarousel
         onTouchEnd={handleTouchEnd}
         onClick={() => onImageClick(
           getImageUrl(allImages[currentImageIndex] || null),
-          property.title
+          property.title,
+          allImages,
+          currentImageIndex
         )}
         style={{
           WebkitTouchCallout: 'none',

--- a/src/components/dashboard/PropertiesBrowser.tsx
+++ b/src/components/dashboard/PropertiesBrowser.tsx
@@ -23,12 +23,12 @@ interface PropertiesBrowserProps {
   onCancelApplication: (applicationId: string) => void
   onSaveProperty: (propertyId: string) => void
   onUnsaveProperty: (propertyId: string) => void
-  onImageClick: (src: string | null, alt: string) => void
+  onImageClick: (src: string | null, alt: string, allImages?: string[], initialIndex?: number) => void
 }
 
 interface PropertyImageCarouselProps {
   property: Property
-  onImageClick: (src: string | null, alt: string) => void
+  onImageClick: (src: string | null, alt: string, allImages?: string[], initialIndex?: number) => void
   height?: string
 }
 
@@ -102,7 +102,9 @@ function PropertyImageCarousel({ property, onImageClick, height = "h-48" }: Prop
         onTouchEnd={handleTouchEnd}
         onClick={() => onImageClick(
           getImageUrl(allImages[currentImageIndex] || null),
-          property.title
+          property.title,
+          allImages,
+          currentImageIndex
         )}
         style={{
           WebkitTouchCallout: 'none',

--- a/src/components/dashboard/SavedProperties.tsx
+++ b/src/components/dashboard/SavedProperties.tsx
@@ -7,7 +7,7 @@ interface SavedPropertiesProps {
   onApplyToProperty: (propertyId: string) => void
   onCancelApplication: (applicationId: string) => void
   onUnsaveProperty: (propertyId: string) => void
-  onImageClick: (src: string | null, alt: string) => void
+  onImageClick: (src: string | null, alt: string, allImages?: string[], initialIndex?: number) => void
   setActiveTab: (tab: DashboardTab) => void
 }
 
@@ -62,56 +62,75 @@ export default function SavedProperties({
       <h3 className="text-xl font-bold text-gray-900 dark:text-white mb-6">Saved Properties</h3>
       
       <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
-        {savedProperties.map((savedProperty) => (
-          <div key={savedProperty.id} className="bg-white dark:bg-gray-800 rounded-2xl shadow-md hover:shadow-lg transition-shadow">
-            <button
-              onClick={() => onImageClick(
-                savedProperty.property?.image_url || null, 
-                savedProperty.property?.title || 'Property'
-              )}
-              className="w-full h-48 object-cover rounded-t-2xl"
-            >
-              <PropertyImage
-                src={savedProperty.property?.image_url || null}
-                alt={savedProperty.property?.title || 'Property'}
-                className="w-full h-full object-cover rounded-t-2xl"
-              />
-            </button>
-            <div className="p-6">
-              <h4 className="font-bold text-lg text-gray-900 dark:text-white mb-2">
-                {savedProperty.property?.title}
-              </h4>
-              <p className="text-gray-600 dark:text-gray-400 text-sm mb-2">
-                {savedProperty.property?.location}
-              </p>
-              {savedProperty.property?.price && (
-                <p className="text-xl font-bold text-blue-600 dark:text-blue-400 mb-4">
-                  ${Number(savedProperty.property.price).toFixed(2)}/month
+        {savedProperties.map((savedProperty) => {
+          const property = savedProperty.property
+          if (!property) return null
+
+          const allImages: string[] = []
+          if (property.image_url) {
+            allImages.push(property.image_url)
+          }
+          if (property.image_urls && property.image_urls.length > 0) {
+            property.image_urls.forEach(url => {
+              if (url && url !== property.image_url) {
+                allImages.push(url)
+              }
+            })
+          }
+
+          return (
+            <div key={savedProperty.id} className="bg-white dark:bg-gray-800 rounded-2xl shadow-md hover:shadow-lg transition-shadow">
+              <button
+                onClick={() => onImageClick(
+                  allImages[0] || null,
+                  property.title || 'Property',
+                  allImages,
+                  0
+                )}
+                className="w-full h-48 object-cover rounded-t-2xl"
+              >
+                <PropertyImage
+                  src={allImages[0] || null}
+                  alt={property.title || 'Property'}
+                  className="w-full h-full object-cover rounded-t-2xl"
+                />
+              </button>
+              <div className="p-6">
+                <h4 className="font-bold text-lg text-gray-900 dark:text-white mb-2">
+                  {property.title}
+                </h4>
+                <p className="text-gray-600 dark:text-gray-400 text-sm mb-2">
+                  {property.location}
                 </p>
-              )}
-              
-              <div className="flex gap-2">
-                <button
-                  onClick={() => handleApplyClick(savedProperty)}
-                  disabled={false}
-                  className={`flex-1 px-3 py-2 text-sm font-medium rounded-lg transition-colors ${
-                    hasAppliedToProperty(savedProperty.bed_id)
-                      ? 'bg-red-600 text-white hover:bg-red-700'
-                      : 'bg-blue-600 text-white hover:bg-blue-700'
-                  }`}
-                >
-                  {hasAppliedToProperty(savedProperty.bed_id) ? 'Cancel Application' : 'Apply'}
-                </button>
-                <button
-                  onClick={() => onUnsaveProperty(savedProperty.bed_id)}
-                  className="px-3 py-2 text-sm font-medium bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors"
-                >
-                  Remove
-                </button>
+                {property.price && (
+                  <p className="text-xl font-bold text-blue-600 dark:text-blue-400 mb-4">
+                    ${Number(property.price).toFixed(2)}/month
+                  </p>
+                )}
+
+                <div className="flex gap-2">
+                  <button
+                    onClick={() => handleApplyClick(savedProperty)}
+                    disabled={false}
+                    className={`flex-1 px-3 py-2 text-sm font-medium rounded-lg transition-colors ${
+                      hasAppliedToProperty(savedProperty.bed_id)
+                        ? 'bg-red-600 text-white hover:bg-red-700'
+                        : 'bg-blue-600 text-white hover:bg-blue-700'
+                    }`}
+                  >
+                    {hasAppliedToProperty(savedProperty.bed_id) ? 'Cancel Application' : 'Apply'}
+                  </button>
+                  <button
+                    onClick={() => onUnsaveProperty(savedProperty.bed_id)}
+                    className="px-3 py-2 text-sm font-medium bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors"
+                  >
+                    Remove
+                  </button>
+                </div>
               </div>
             </div>
-          </div>
-        ))}
+          )
+        })}
       </div>
     </div>
   )


### PR DESCRIPTION
The image modal in the dashboard was not allowing users to scroll through multiple images of a property. This was because the `ImageModal` component was not being supplied with the array of all images for the property.

This commit updates the `onImageClick` handler and the components that use it (`PropertiesBrowser`, `AgentProperties`, and `SavedProperties`) to pass the full image gallery data to the `ImageModal`. This enables the swipe/scroll functionality, making the dashboard's image viewer consistent with the one on the home page.