### PR TITLE
fix(types): Correct Application type for receipts

### DIFF
--- a/src/types/dashboard.ts
+++ b/src/types/dashboard.ts
@@ -89,6 +89,7 @@ export interface Application {
       name?: string | null
       room_type?: 'single' | 'double' | 'triple' | 'quad'
       price_per_bed?: number
+      property?: Property
     } | null
   } | null
 }


### PR DESCRIPTION
This commit fixes a type definition issue in `src/types/dashboard.ts` that was preventing agent details from being correctly displayed on receipts for agent users.

The `room` object within the `Application` interface was missing the optional `property` field. This caused the `property` object, which contained the agent's details, to be stripped out during type casting in `ReceiptsView.tsx` when preparing the data for the `ReceiptCard`.

This commit adds `property?: Property` to the `room` type definition, ensuring that the agent's profile information is correctly passed to the `ReceiptCard` component. This change is made in conjunction with the previous modifications to `ReceiptsView.tsx` to ensure agent details are available for all user roles.